### PR TITLE
Removed cl image tag until we implement image upload

### DIFF
--- a/app/views/musicians/show.html.erb
+++ b/app/views/musicians/show.html.erb
@@ -1,7 +1,7 @@
 <h1>Musicians#show</h1>
 <p>Find me in app/views/musicians/show.html.erb</p>
 
-<%= cl_image_tag(@musician.photo, height: '200') %>
+<%= image_tag(@musician.photo, height: '200') %>
 <h2><%= @musician.first_name %> <%= @musician.last_name %></h2>
 
 <h3>About</h3>


### PR DESCRIPTION
The code was breaking on the musician show page, I have to remove cl from cl_image_tag, since we still have regular url for the photos.